### PR TITLE
fix(financial-hub): Ensure account balance updates in UI after transa…

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -178,6 +178,7 @@ const AccountCard: React.FC<AccountCardProps> = ({ account, onUpdate }) => {
           isOpen={showAccountDetailsModal}
           onClose={() => setShowAccountDetailsModal(false)}
           account={account}
+          onUpdate={onUpdate}
         />
       )}
 

--- a/src/components/AccountDetailsModal.tsx
+++ b/src/components/AccountDetailsModal.tsx
@@ -10,12 +10,14 @@ interface AccountDetailsModalProps {
   isOpen: boolean;
   onClose: () => void;
   account: Account;
+  onUpdate: () => void;
 }
 
 const AccountDetailsModal: React.FC<AccountDetailsModalProps> = ({
   isOpen,
   onClose,
-  account
+  account,
+  onUpdate
 }) => {
   const [user, setUser] = useState<User | null>(null);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
@@ -160,8 +162,9 @@ const AccountDetailsModal: React.FC<AccountDetailsModalProps> = ({
       await forceUpdateAccountBalance(user.uid, account.id);
       console.log('✅ Account balance force updated after transaction deletion');
       
-      // Reload transactions
+      // Reload transactions and trigger full refresh
       await loadTransactions();
+      onUpdate();
     } catch (error) {
       console.error('Error deleting transaction:', error);
       setError('Failed to delete transaction');
@@ -180,8 +183,9 @@ const AccountDetailsModal: React.FC<AccountDetailsModalProps> = ({
       await forceUpdateAccountBalance(user.uid, account.id);
       console.log('✅ Account balance force updated after transaction edit');
       
-      // Reload transactions
+      // Reload transactions & trigger full refresh
       await loadTransactions();
+      onUpdate();
       
       setEditingTransaction(null);
     } catch (error) {
@@ -389,6 +393,7 @@ const AccountDetailsModal: React.FC<AccountDetailsModalProps> = ({
           onTransactionAdded={() => {
             setShowAddTransactionModal(false);
             loadTransactions(); // Refresh transaction list
+            onUpdate(); // <--- Trigger a full data refresh
           }}
         />
       )}


### PR DESCRIPTION
…ctions

The account balance on the Financial Hub page and within the Account Details modal was not updating immediately after a new transaction was added, edited, or deleted.

This was because the UI state was not being synchronized with the updated database state. The `forceUpdateAccountBalance` function correctly updated the balance in Firestore, but there was no mechanism to signal to the top-level `FinancialHubPage` that it needed to re-fetch the account data.

I fixed the issue by:
1.  Propagating the `onUpdate` function from `FinancialHubPage` down through `AccountCard` to `AccountDetailsModal`.
2.  Calling this `onUpdate` function from within `AccountDetailsModal` after any transaction is created, updated, or deleted.

This triggers a refresh of the account data on the main page, ensuring the UI always displays the correct, up-to-date balance.